### PR TITLE
feat: MCP 도구 이미지 결과 지원 및 HTTP transport 개선

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,7 +6,7 @@ import {
   mcpToolToFunctionDeclaration,
 } from "@/lib/gemini";
 import { mcpClientManager } from "@/lib/mcp/client-manager";
-import type { McpToolInfo } from "@/types/mcp";
+import type { McpToolInfo, McpToolResult } from "@/types/mcp";
 
 interface ToolMapping {
   serverId: string;
@@ -93,12 +93,15 @@ export async function POST(request: NextRequest) {
           const { toolMap, allTools } = buildToolMap(serverTools);
           const declarations = allTools.map(mcpToolToFunctionDeclaration);
 
+          const toolResultRef: { current: McpToolResult | null } = { current: null };
+
           const onToolCall = async (
             name: string,
             args: Record<string, unknown>,
           ): Promise<Record<string, unknown>> => {
             const mapping = toolMap.get(name);
             if (!mapping) {
+              toolResultRef.current = null;
               return { error: `도구를 찾을 수 없습니다: ${name}` };
             }
 
@@ -107,14 +110,22 @@ export async function POST(request: NextRequest) {
               mapping.originalName,
               args,
             );
+            toolResultRef.current = result;
 
             const textParts = result.content
-              .filter((c) => c.text)
+              .filter((c) => c.type === "text" && c.text)
               .map((c) => c.text)
               .join("\n");
+            const imageCount = result.content.filter(
+              (c) => c.type === "image",
+            ).length;
+            const summary =
+              imageCount > 0
+                ? `${textParts ? textParts + "\n" : ""}[${imageCount}개 이미지 생성됨]`
+                : textParts;
 
             return {
-              result: textParts || JSON.stringify(result.content),
+              result: summary || JSON.stringify(result.content),
               isError: result.isError ?? false,
             };
           };
@@ -146,6 +157,11 @@ export async function POST(request: NextRequest) {
               const mapping = toolMap.get(event.name);
               const resultData = event.result as Record<string, unknown>;
               const isError = resultData.error !== undefined;
+              const capturedContent = toolResultRef.current?.content ?? [
+                { type: "text" as const, text: String(resultData.result ?? "") },
+              ];
+              toolResultRef.current = null;
+
               send({
                 type: "tool_call_result",
                 toolCall: {
@@ -157,12 +173,7 @@ export async function POST(request: NextRequest) {
                   status: isError ? "error" : "success",
                   result: isError
                     ? undefined
-                    : {
-                        content: [
-                          { type: "text", text: String(resultData.result ?? "") },
-                        ],
-                        isError: false,
-                      },
+                    : { content: capturedContent, isError: false },
                   error: isError ? String(resultData.error) : undefined,
                   startedAt: Date.now(),
                   completedAt: Date.now(),

--- a/components/chat/ToolCallBubble.tsx
+++ b/components/chat/ToolCallBubble.tsx
@@ -102,13 +102,27 @@ function ToolCallBubbleInner({ toolCall }: ToolCallBubbleProps) {
           {toolCall.result && (
             <div>
               <p className="text-foreground/40 mb-1">결과</p>
-              <pre className="rounded bg-foreground/[0.03] p-2 overflow-x-auto text-[11px] leading-relaxed max-h-48">
-                {toolCall.result.content
-                  .map((c) => c.text ?? "")
-                  .filter(Boolean)
-                  .join("\n") ||
-                  JSON.stringify(toolCall.result.content, null, 2)}
-              </pre>
+              {toolCall.result.content
+                .filter((c) => c.type === "image" && c.data)
+                .map((c, i) => (
+                  <img
+                    key={i}
+                    src={`data:${c.mimeType ?? "image/png"};base64,${c.data}`}
+                    alt={`${toolCall.toolName} 결과 이미지`}
+                    className="rounded-md max-w-full max-h-64 my-1"
+                  />
+                ))}
+              {toolCall.result.content.some(
+                (c) => c.type === "text" && c.text,
+              ) && (
+                <pre className="rounded bg-foreground/[0.03] p-2 overflow-x-auto text-[11px] leading-relaxed max-h-48">
+                  {toolCall.result.content
+                    .filter((c) => c.type === "text")
+                    .map((c) => c.text ?? "")
+                    .filter(Boolean)
+                    .join("\n")}
+                </pre>
+              )}
             </div>
           )}
         </div>

--- a/components/mcp/McpServerForm.tsx
+++ b/components/mcp/McpServerForm.tsx
@@ -62,8 +62,6 @@ export function McpServerForm({
   const [url, setUrl] = useState("");
   const [headers, setHeaders] = useState<KeyValuePair[]>([]);
 
-  const [httpEnvVars, setHttpEnvVars] = useState<KeyValuePair[]>([]);
-
   const [command, setCommand] = useState("");
   const [args, setArgs] = useState("");
   const [envVars, setEnvVars] = useState<KeyValuePair[]>([]);
@@ -77,7 +75,6 @@ export function McpServerForm({
       if (editingServer.transport.type === "streamable-http") {
         setUrl(editingServer.transport.url);
         setHeaders(toKeyValuePairs(editingServer.transport.headers));
-        setHttpEnvVars(toKeyValuePairs(editingServer.transport.env));
         setCommand("");
         setArgs("");
         setEnvVars([]);
@@ -87,14 +84,12 @@ export function McpServerForm({
         setEnvVars(toKeyValuePairs(editingServer.transport.env));
         setUrl("");
         setHeaders([]);
-        setHttpEnvVars([]);
       }
     } else {
       setName("");
       setTransportType("streamable-http");
       setUrl("");
       setHeaders([]);
-      setHttpEnvVars([]);
       setCommand("");
       setArgs("");
       setEnvVars([]);
@@ -110,7 +105,6 @@ export function McpServerForm({
         type: "streamable-http",
         url,
         headers: toRecord(headers),
-        env: toRecord(httpEnvVars),
       };
     } else {
       const parsedArgs = args
@@ -210,9 +204,6 @@ export function McpServerForm({
                   value={url}
                   onChange={(e) => setUrl(e.target.value)}
                 />
-                <p className="text-[10px] text-muted-foreground">
-                  {"환경 변수에 등록한 값을 ${KEY} 형식으로 참조할 수 있습니다."}
-                </p>
               </div>
               <KeyValueEditor
                 label="Headers"
@@ -221,17 +212,7 @@ export function McpServerForm({
                 onUpdate={(i, f, v) => updatePair(setHeaders, i, f, v)}
                 onRemove={(i) => removePair(setHeaders, i)}
                 keyPlaceholder="Authorization"
-                valuePlaceholder="Bearer ${API_KEY}"
-              />
-              <KeyValueEditor
-                label="환경 변수"
-                pairs={httpEnvVars}
-                onAdd={() => addPair(setHttpEnvVars)}
-                onUpdate={(i, f, v) => updatePair(setHttpEnvVars, i, f, v)}
-                onRemove={(i) => removePair(setHttpEnvVars, i)}
-                keyPlaceholder="HF_TOKEN"
-                valuePlaceholder="hf_xxxxx..."
-                hint={"URL·Headers에서 ${KEY} 형식으로 참조됩니다."}
+                valuePlaceholder="Bearer token..."
               />
             </>
           ) : (

--- a/components/mcp/McpToolRunner.tsx
+++ b/components/mcp/McpToolRunner.tsx
@@ -174,11 +174,24 @@ export function McpToolRunner({ serverId, tools }: McpToolRunnerProps) {
                     </Badge>
                   )}
                 </div>
-                <pre className="whitespace-pre-wrap font-mono text-xs">
-                  {result.content
-                    .map((c) => c.text ?? JSON.stringify(c))
-                    .join("\n")}
-                </pre>
+                {result.content
+                  .filter((c) => c.type === "image" && c.data)
+                  .map((c, i) => (
+                    <img
+                      key={i}
+                      src={`data:${c.mimeType ?? "image/png"};base64,${c.data}`}
+                      alt="도구 결과 이미지"
+                      className="rounded-md max-w-full max-h-80 my-1.5"
+                    />
+                  ))}
+                {result.content.some((c) => c.type !== "image") && (
+                  <pre className="whitespace-pre-wrap font-mono text-xs">
+                    {result.content
+                      .filter((c) => c.type !== "image")
+                      .map((c) => c.text ?? JSON.stringify(c))
+                      .join("\n")}
+                  </pre>
+                )}
               </div>
             )}
           </>

--- a/lib/mcp/client-manager.ts
+++ b/lib/mcp/client-manager.ts
@@ -9,6 +9,7 @@ import type {
   McpToolInfo,
   McpPromptInfo,
   McpResourceInfo,
+  McpContentPart,
   McpToolResult,
   McpPromptResult,
   McpResourceResult,
@@ -120,7 +121,7 @@ class McpClientManager {
     const client = this.getConnectedClient(serverId);
     const result = await client.callTool({ name: toolName, arguments: args });
     return {
-      content: (result.content as { type: string; text?: string }[]) ?? [],
+      content: (result.content as McpContentPart[]) ?? [],
       isError: result.isError as boolean | undefined,
     };
   }

--- a/lib/mcp/client-manager.ts
+++ b/lib/mcp/client-manager.ts
@@ -167,33 +167,13 @@ class McpClientManager {
     this.connections.delete(serverId);
   }
 
-  private resolveEnvVars(
-    value: string,
-    localEnv?: Record<string, string>,
-  ): string {
-    return value.replace(
-      /\$\{(\w+)\}/g,
-      (_, key) => localEnv?.[key] ?? process.env[key] ?? "",
-    );
-  }
-
   private createTransport(
     config: McpTransportConfig,
   ): StreamableHTTPClientTransport | StdioClientTransport {
     if (config.type === "streamable-http") {
-      const env = config.env;
-      const resolvedUrl = this.resolveEnvVars(config.url, env);
-      const resolvedHeaders = config.headers
-        ? Object.fromEntries(
-            Object.entries(config.headers).map(([k, v]) => [
-              k,
-              this.resolveEnvVars(v, env),
-            ]),
-          )
-        : undefined;
-      return new StreamableHTTPClientTransport(new URL(resolvedUrl), {
-        requestInit: resolvedHeaders
-          ? { headers: resolvedHeaders }
+      return new StreamableHTTPClientTransport(new URL(config.url), {
+        requestInit: config.headers
+          ? { headers: config.headers }
           : undefined,
       });
     }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  turbopack: {
-    root: __dirname,
-  },
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -5,7 +5,7 @@ export interface ToolCallInfo {
   toolName: string;
   args: Record<string, unknown>;
   status: "calling" | "success" | "error";
-  result?: { content: { type: string; text?: string }[]; isError?: boolean };
+  result?: { content: { type: string; text?: string; data?: string; mimeType?: string }[]; isError?: boolean };
   error?: string;
   startedAt: number;
   completedAt?: number;

--- a/types/mcp.ts
+++ b/types/mcp.ts
@@ -65,6 +65,8 @@ export interface McpServerStatus {
 export interface McpContentPart {
   type: string;
   text?: string;
+  data?: string;
+  mimeType?: string;
 }
 
 export interface McpToolResult {

--- a/types/mcp.ts
+++ b/types/mcp.ts
@@ -4,7 +4,6 @@ export interface StreamableHttpTransport {
   type: "streamable-http";
   url: string;
   headers?: Record<string, string>;
-  env?: Record<string, string>;
 }
 
 export interface StdioTransport {


### PR DESCRIPTION
Resolved #3

## Summary

MCP 도구가 이미지를 생성하는 경우 인스펙터와 채팅방 모두에서 이미지를 직접 렌더링할 수 있도록 지원을 추가합니다. 또한 HTTP transport에서 불필요한 env 전달을 제거하고 헤더를 직접 수신하도록 단순화합니다.

## Changes

- `types/mcp.ts`, `types/chat.ts`: `McpContentPart`에 `data`(base64), `mimeType` 필드 추가
- `lib/mcp/client-manager.ts`: `callTool` 결과를 `McpContentPart[]`로 캐스팅해 이미지 필드 보존, HTTP transport env 제거
- `app/api/chat/route.ts`: `onToolCall`에서 이미지 개수를 Gemini 요약 텍스트에 포함하고, `tool_call_result` SSE 이벤트에 원본 content parts(이미지 포함) 전달
- `components/chat/ToolCallBubble.tsx`: `type: "image"` 콘텐츠를 base64 data URI로 `img` 태그 렌더링
- `components/mcp/McpToolRunner.tsx`: 인스펙터에서도 동일하게 이미지 렌더링 지원
- `next.config.ts`: 불필요한 turbopack root 설정 제거

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- MCP `generate-image` 도구 호출 시 채팅방 버블에서 이미지 직접 렌더링 확인
- McpToolRunner(인스펙터)에서도 이미지 렌더링 확인
- 텍스트 결과 기존 동작 정상 확인

## Checklist

- [x] I have tested this change locally
- [x] I have updated documentation if needed
- [x] This change does not introduce security vulnerabilities